### PR TITLE
Add CI/CD Pipelines for PR, Dev Release, and Prod Release

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -10,11 +10,6 @@ jobs:
     name: Build & Test (Java 21)
     runs-on: ubuntu-latest
 
-    env:
-      DB_URL: ${{ secrets.DB_URL }}
-      DB_USERNAME: ${{ secrets.DB_USERNAME }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,8 +2,7 @@ name: PR CI pre build check
 
 on:
   pull_request:
-    branches:
-      - dev
+    branches: [ dev ]
 
 jobs:
   build-test:
@@ -21,5 +20,5 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
-      - name: Build & Test
+      - name: Build & Test (H2 test profile)
         run: mvn -B -DskipTests=false verify

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -6,19 +6,15 @@ on:
 
 jobs:
   build-test:
-    name: Build & Test (Java 21)
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: '21'
-          cache: 'maven'
+          cache: maven
 
-      - name: Build & Test (H2 test profile)
+      # Surefire already sets spring.profiles.active=test
+      - name: Build & Test (H2)
         run: mvn -B -DskipTests=false verify

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,6 +1,8 @@
 name: PR CI pre build check
 
 on:
+  push:
+    branches: [ dev ]
   pull_request:
     branches: [ dev ]
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,4 @@
-name: PR CI
+name: PR CI pre build check
 
 on:
   pull_request:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+  workflow_dispatch: {}
 
 concurrency:
   group: dev-release

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,0 +1,94 @@
+name: Prod Release (image only)
+
+on:
+  push:
+    branches: [ main ]         # merge to main triggers prod image
+    tags:     [ 'v*.*.*' ]     # optional semantic version tags
+
+concurrency:
+  group: prod-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  JAVA_VERSION: '21'
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/todo-api
+  DOCKER_CONTEXT: ./isys3001-todo-backend
+  DOCKERFILE_PATH: ./isys3001-todo-backend/Dockerfile
+
+jobs:
+  verify:
+    name: Build & Test (gate)
+    runs-on: ubuntu-latest
+
+    env:
+      DB_URL: ${{ secrets.DB_URL }}
+      DB_USERNAME: ${{ secrets.DB_USERNAME }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+
+    outputs:
+      sha_tag: ${{ steps.sha.outputs.tag }}
+      ver_tag: ${{ steps.ver.outputs.tag }}
+      ver_minor: ${{ steps.ver.outputs.minor }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: maven
+
+      - name: Build & Test
+        run: mvn -B -DskipTests=false verify
+
+      - name: Compute SHA tag
+        id: sha
+        run: echo "tag=prod-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      # If this is a tag like v1.2.3, produce extra tags 1.2.3 and 1.2
+      - name: Parse semver tag (if any)
+        id: ver
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v*.*.* ]]; then
+            V="${GITHUB_REF#refs/tags/v}"
+            echo "tag=${V}" >> "$GITHUB_OUTPUT"
+            echo "minor=${V%.*}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "minor=" >> "$GITHUB_OUTPUT"
+          fi
+
+  docker:
+    name: Build & Push Docker (GHCR)
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & Push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.DOCKER_CONTEXT }}
+          file: ${{ env.DOCKERFILE_PATH }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ needs.verify.outputs.sha_tag }}
+            ${{ env.IMAGE_NAME }}:prod-latest
+            ${{ needs.verify.outputs.ver_tag && format('{0}:{1}', env.IMAGE_NAME, needs.verify.outputs.ver_tag) || '' }}
+            ${{ needs.verify.outputs.ver_minor && format('{0}:{1}', env.IMAGE_NAME, needs.verify.outputs.ver_minor) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]         # merge to main triggers prod image
     tags:     [ 'v*.*.*' ]     # optional semantic version tags
+  workflow_dispatch: {}
 
 concurrency:
   group: prod-release

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
             <artifactId>jjwt-jackson</artifactId>
             <version>0.12.6</version>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,16 @@
 					</excludes>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <spring.profiles.active>test</spring.profiles.active>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+# Let Spring auto-detect the MySQL driver; don't force it
+# (Remove spring.datasource.driver-class-name to avoid leaking into tests)
+# If you insist on setting it, do it here (NOT in base):
+# spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,11 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
+# disable migrations in unit tests (optional)
+spring.flyway.enabled=false
+spring.liquibase.enabled=false
+spring.sql.init.mode=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,12 @@ spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
+spring.flyway.enabled=false
+spring.liquibase.enabled=false
+spring.sql.init.mode=never
+
+# Quieter logs (optional)
+logging.level.org.hibernate.SQL=warn

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,3 @@
 spring.application.name=todo-backend
-spring.datasource.url=${DB_URL}
-spring.datasource.username=${DB_USERNAME}
-spring.datasource.password=${DB_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
 spring.jpa.hibernate.ddl-auto=update
-
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
-
-spring.flyway.enabled=false
-spring.liquibase.enabled=false
-spring.sql.init.mode=never
-
-# Quieter logs (optional)
-logging.level.org.hibernate.SQL=warn
+spring.jpa.show-sql=false


### PR DESCRIPTION
## 🚀 CI/CD Pipelines Added - [Issue-#7](https://github.com/radeesh851-a11y/isys3001-todo-backend/issues/7)

### 🔍 Pull Request CI (`ci-pr.yml`)
- Runs on every PR into `develop`.
- Builds & tests the project with Java 21 (`mvn verify`).
- Blocks merging if checks fail (branch protection enabled).

### 🧪 Dev Release (`release-dev.yml`)
- Triggers on merge into `dev`.
- Builds & tests again as a safety gate.
- Pushes Docker images to **GHCR** with tags:
  - `dev-<commit-sha>`
  - `dev-latest`

### 📦 Prod Release (`release-main.yml`)
- Triggers on merge into `main`.
- Builds & tests again before release.
- Pushes Docker images to **GHCR** with tags:
  - `prod-<commit-sha>`
  - `prod-latest`
- (Optional) When a version tag (`vX.Y.Z`) is pushed:
  - `X.Y.Z` (pinned)
  - `X.Y` (floating minor)

### ✅ Benefits
- Ensures only tested code reaches `dev` and `main`.
- Provides reproducible Docker images for every commit.
- Supports semantic versioning for professional release flows.
- Demonstrates full CI/CD integration (ready for assignment submission).
